### PR TITLE
Feat/app extension communication

### DIFF
--- a/client/app/features/chat/chat.html
+++ b/client/app/features/chat/chat.html
@@ -84,7 +84,7 @@
         <div class="sendMessage">
           <form ng-submit='sendMessage(messageText)' name='messageForm'>
             <input class="sendMessageInput" type='text' name='message' ng-model='messageText' maxlength="120" required/>
-            <input ng-disabled='!messageForm.$valid || !activeFriend.key' type='submit' value='send'/>
+            <input ng-disabled='!messageForm.$valid' type='submit' value='send'/>
           </form>
         </div>
 

--- a/client/app/features/chat/chat.js
+++ b/client/app/features/chat/chat.js
@@ -37,6 +37,7 @@ angular.module('Locket.chat', ['luegg.directives'])
         if (event.data.type && (event.data.type == 'receivedNewFacebookMessage')) {
           var username = event.data.text.from;
           var newMessages = event.data.text.text;
+          // TODO fix/reenable this
           findFriend(username, function(index) {
             for (var i = 0; i < newMessages.length; i++) {
               $scope.friends[index].messages.push({
@@ -45,11 +46,15 @@ angular.module('Locket.chat', ['luegg.directives'])
                 timestamp: Date.now(),
                 message: newMessages[i]
               });
+              if ($scope.friends[index].username !== $scope.activeFriend.username) {
+                $scope.friends[index].unreadMessage = true;
+              }
             }
           });
-          console.log('client: received new msg', event.data);
-        }
+          $scope.$apply();
+        };
       });
+
 
       $scope.friendRequests = [];
       $scope.acceptedfriendRequests = [];

--- a/extension/proof-of-concept/facebook.js
+++ b/extension/proof-of-concept/facebook.js
@@ -1,6 +1,8 @@
+console.log('facebook');
 var backgroundCheckInterval = 1000;
 var rescanDOMInteral = 3000;
 var seenMessageGroup = {};
+var usersWithNewMessages = [];
 
 $(document).ready(function() {
   // Facebook has iFrames. 
@@ -62,6 +64,7 @@ $(document).ready(function() {
 
     // Check for new messages from facebook DOM
     var rescanFacebookDom = function() {
+      // Check for new messages from non-active users
       $('#webMessengerRecentMessages li').each(function(idx) {
         //console.log($(this).find('p').text());
         var texts = $(this).find('p');
@@ -81,6 +84,16 @@ $(document).ready(function() {
           seenMessageGroup[id] = texts;
         }
       });
+      usersWithNewMessages = [];
+      $('._k_').each(function(idx) {
+        if ($(this).find('._l6').text().indexOf('new') !== -1) {
+          usersWithNewMessages.push(this);
+        }
+      });
+      if (usersWithNewMessages.length !== 0) {
+        usersWithNewMessages[0].click();
+        usersWithNewMessages.shift();
+      }
     };
 
     setInterval(checkWithBackgroundProcess, backgroundCheckInterval);

--- a/extension/proof-of-concept/notes
+++ b/extension/proof-of-concept/notes
@@ -32,6 +32,19 @@ NEXT STEP:
 
 Ability to read & send messages to facebook from our web application
 
+----------------------------
 
+CURRENT PROBLEM:
+
+How to handle receiving messages from somebody on facebook who isnt our active user?
+1) reload the entire page. Baaaaaaaaad idea. We'll lose all state on our facebook.js
+2) click the button. Better idea. How can we make sure we're not still loading though? Is it that big a deal? It honestly mostly seems to work...but I could imagine some race conditions where it might not.
+  - POTENTIAL RACE CONDITION: 
+    - click a new user
+    - waiting for that user to load
+    - in the meantime, get a message from the existing user, after the url has changed
+    - mistakenly associate the new message with the new user, instead of the existing user
+  - FIX:
+    - change association of messages to usernames to be based on the urls inside the messagebox
 
 


### PR DESCRIPTION
Minor changes to html and chat.js as necessary to un-break things

Big feature here is the ability to receive messages from facebook users who are not your currently active facebook conversation.

Note that we do not yet have the ability to send messages to facebook users who are not your currently active facebook conversation. 

Also note that there is one outstanding todo: we want to change the way of getting the facebook new messages' username from looking at window.location to getting it from the message. This will be more consistent and will be more closely related to how we will be able to send to any facebook user in our friends list.